### PR TITLE
Updated survey js to accommodate span tags for ACTIV-6

### DIFF
--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -764,6 +764,9 @@ var Multilingual = (function(){
 					
 					if (translate_mode == 'text') {
 						var nodes = $('#label-' + id).contents();
+						if(nodes.length == 1 && nodes[0].nodeType == 1 && nodes[0].nodeName == 'DIV') {
+							nodes = $('#label-' + id + ' [data-mlm-field="'+id+'"]').contents();
+						}
 						for (var i = 0; i < nodes.length; i++) {
 							// replace textContent of first text type node
 							if (!nodes[i] || !nodes[i].nodeType)
@@ -775,12 +778,18 @@ var Multilingual = (function(){
 						};
 					} else {
 						// replace text node content sequentially
-						var tnodes1 = getTextNodesIn($('#label-' + id)[0])
+						var tnodes1 = [];
+						var tnodes2 = [];
 						
-						translation.each(function(i, text) {
-							if (tnodes1[i]) {
-								tnodes1[i].textContent = text.innerText ?? text.outerText;
-							}
+						translation.each(function(inc, text) {
+							tnodes1 = getTextNodesIn($('#label-' + id + ' [data-mlm-field="'+id+'"]')[0].children[inc]);
+							tnodes2 = getTextNodesIn(translation[inc]);
+
+							tnodes2.forEach(function(el, i) {
+								if(tnodes2[i].length > 0 && typeof tnodes1[i] !== 'undefined') {
+									tnodes1[i].textContent = el.textContent;
+								}
+							});
 						});
 					}
 				}

--- a/js/multilingual_survey.js
+++ b/js/multilingual_survey.js
@@ -786,7 +786,7 @@ var Multilingual = (function(){
 							tnodes2 = getTextNodesIn(translation[inc]);
 
 							tnodes2.forEach(function(el, i) {
-								if(tnodes2[i].length > 0 && typeof tnodes1[i] !== 'undefined') {
+								if(tnodes1[i].length > 0 && typeof tnodes1[i] !== 'undefined') {
 									tnodes1[i].textContent = el.textContent;
 								}
 							});


### PR DESCRIPTION
This was to address an issue on the ACTIV-6 project (PID: 130476) where everything before a span tag was being translated, but nothing within or after the tag was. I found several other instances of translation issues while testing this, and this fix appears to address all the ones I encountered.

[a6 Language module issues.docx](https://github.com/vanderbilt-redcap/Multilingual/files/9865233/a6.Language.module.issues.docx)